### PR TITLE
Do not create loadorder.txt when initializing profile

### DIFF
--- a/src/gamefallout4vr.cpp
+++ b/src/gamefallout4vr.cpp
@@ -109,7 +109,6 @@ void GameFallout4VR::initializeProfile(const QDir &path, ProfileSettings setting
 {
   if (settings.testFlag(IPluginGame::MODS)) {
     copyToProfile(localAppFolder() + "/Fallout4VR", path, "plugins.txt");
-    copyToProfile(localAppFolder() + "/Fallout4VR", path, "loadorder.txt");
   }
 
   if (settings.testFlag(IPluginGame::CONFIGURATION)) {

--- a/src/gamefallout4vr.cpp
+++ b/src/gamefallout4vr.cpp
@@ -97,7 +97,7 @@ QString GameFallout4VR::description() const
 
 MOBase::VersionInfo GameFallout4VR::version() const
 {
-  return VersionInfo(1, 5, 0, VersionInfo::RELEASE_FINAL);
+  return VersionInfo(1, 6, 0, VersionInfo::RELEASE_FINAL);
 }
 
 QList<PluginSetting> GameFallout4VR::settings() const


### PR DESCRIPTION
The original intention behind loadorder.txt is to simply report the
load order of plugins to other applications. If the file is not a
known, good load order from MO2, it should not be used to change
the load order.