### PR TITLE
Re-Enable ESL Plugins for Fallout 4 VR

### DIFF
--- a/src/fallout4vrgameplugins.cpp
+++ b/src/fallout4vrgameplugins.cpp
@@ -7,6 +7,9 @@ Fallout4VRGamePlugins::Fallout4VRGamePlugins(MOBase::IOrganizer* organizer)
 {}
 
 bool Fallout4VRGamePlugins::lightPluginsAreSupported()
-{
-  return false;
+{    
+    auto files = m_Organizer->findFiles("f4se\\plugins", { "falloutvresl.dll" });
+    if (files.isEmpty())
+        return false;
+    return true;
 }


### PR DESCRIPTION
Fallout 4 VR has experimental ESL thanks to RollingRock's Experimental ESL Support 
[https://github.com/rollingrock/FalloutVRESL/releases/tag/v1.0.1](https://github.com/rollingrock/FalloutVRESL/releases/tag/v1.0.1)

